### PR TITLE
Improve ferroelectric-response.typ

### DIFF
--- a/assets/basis-plus-lattice/basis-plus-lattice.typ
+++ b/assets/basis-plus-lattice/basis-plus-lattice.typ
@@ -4,7 +4,27 @@
 #set page(width: auto, height: auto, margin: 8pt)
 
 #let atom(pos, color) = {
-  circle(pos, radius: 0.25, fill: color.lighten(20%), stroke: 0.3pt)
+  // First draw the base circle with the main color
+  circle(
+    pos,
+    radius: 0.25,
+    stroke: none,
+    fill: color,
+  )
+  // Then draw the gradient overlay for 3D shading effect
+  circle(
+    (),
+    radius: 0.25,
+    stroke: none,
+    fill: gradient.radial(
+      color.lighten(75%),
+      color,
+      color.darken(15%),
+      focal-center: (30%, 25%),
+      focal-radius: 5%,
+      center: (35%, 30%),
+    ),
+  )
 }
 
 #canvas({

--- a/assets/ferroelectric-response/ferroelectric-response.typ
+++ b/assets/ferroelectric-response/ferroelectric-response.typ
@@ -110,7 +110,7 @@
   // Helper function to draw BaTiO3 unit cell
   let atom(pos, radius: 0.20, fill: luma(50), ..args) = {
     circle(
-      pos, 
+      pos,
       radius: radius,
       stroke: none,
       fill: fill,
@@ -200,7 +200,7 @@
       stroke: 1pt,
       name: cell-name + "-bond-" + name,
     )
-    
+
     // --- Back Plane (z = z-offset) ---
     Ba-atom((x - 1, y - 1, z-offset), "back-bl")
     Ba-atom((x + 1, y - 1, z-offset), "back-br")
@@ -208,7 +208,7 @@
     Ba-atom((x + 1, y + 1, z-offset), "back-tr")
     O-atom((x, y, z-offset), "back")
     Ti-O-bond((x, y, z-offset), "back")
-    
+
     // --- Middle Plane (z = z-offset/2) ---
     if ti-y >= 0 {
       Ti-O-bond((x, y + 1, z-offset/2), "top")
@@ -223,7 +223,7 @@
     O-atom((x - 1, y, z-offset/2), "left")
     O-atom((x + 1, y, z-offset/2), "right")
     Ti-atom((x, y + ti-y, z-offset/2))
-    
+
     // --- Front Plane (z = 0) ---
     Ti-O-bond((x, y, 0), "front")
     Ba-atom((x - 1, y - 1, 0), "front-bl")

--- a/assets/ferroelectric-response/ferroelectric-response.typ
+++ b/assets/ferroelectric-response/ferroelectric-response.typ
@@ -120,7 +120,12 @@
       (),
       radius: radius,
       stroke: none,
-      fill: gradient.radial(fill.lighten(75%), fill.lighten(25%), fill, fill.darken(15%), center: (30%, 30%)),
+      fill: gradient.radial(
+        fill.lighten(75%), fill, fill.darken(15%),
+        focal-center: (30%, 25%),
+        focal-radius: 5%,
+        center: (35%, 30%),
+      ),
     )
   }
   let draw-unit-cell(center-x, center-y, ti-y, cell-name) = {
@@ -190,19 +195,19 @@
     let O-atom(pos, name) = atom( pos, fill: red, name: cell-name + "-o-" + name)
     let Ti-atom(pos) = atom( pos, fill: gray, name: cell-name + "-ti")
     let Ti-O-bond(end-pos, name) = line(
-      ((x, y + ti-y, z-offset/2), 16%, end-pos),
-      end-pos,
+      ((x, y + ti-y, z-offset/2), 15%, end-pos),
+      ((x, y + ti-y, z-offset/2), 85%, end-pos),
       stroke: 1pt,
       name: cell-name + "-bond-" + name,
     )
     
     // --- Back Plane (z = z-offset) ---
-    Ti-O-bond((x, y, z-offset), "back")
     Ba-atom((x - 1, y - 1, z-offset), "back-bl")
     Ba-atom((x + 1, y - 1, z-offset), "back-br")
     Ba-atom((x - 1, y + 1, z-offset), "back-tl")
     Ba-atom((x + 1, y + 1, z-offset), "back-tr")
     O-atom((x, y, z-offset), "back")
+    Ti-O-bond((x, y, z-offset), "back")
     
     // --- Middle Plane (z = z-offset/2) ---
     if ti-y >= 0 {

--- a/assets/ferroelectric-response/ferroelectric-response.typ
+++ b/assets/ferroelectric-response/ferroelectric-response.typ
@@ -1,5 +1,5 @@
 #import "@preview/cetz:0.3.4": canvas, draw
-#import draw: rect, line, circle, content, hobby, scale
+#import draw: rect, line, circle, content, hobby, scale, set-origin
 
 #set page(width: auto, height: auto, margin: 8pt)
 
@@ -7,18 +7,18 @@
   let arrow-style = (mark: (end: "stealth", fill: black, scale: .75))
   let plot-height = 4
   let plot-width = 10
-  let y-offset = 4.65 // Reduced from 6 to bring plots closer together
+  let y-offset = 4.5
 
   // Helper to draw axes
   let draw-axes(origin, width, height) = {
     line(
-      (origin.at(0) - 0.5, origin.at(1)),
+      (origin.at(0) - 0.3, origin.at(1)),
       (origin.at(0) + width, origin.at(1)),
       ..arrow-style,
       name: "x-axis",
     )
     line(
-      (origin.at(0), origin.at(1) - 0.5),
+      (origin.at(0), origin.at(1) - 0.3),
       (origin.at(0), origin.at(1) + height),
       ..arrow-style,
       name: "y-axis",
@@ -31,15 +31,16 @@
 
   // Draw double-well potential curve using hobby spline
   hobby(
-    (top-origin.at(0) + .5, top-origin.at(1) + 3.5), // start high
+    (top-origin.at(0) + .5, top-origin.at(1) + 4), // start high
     (top-origin.at(0) + 1.7, top-origin.at(1) + 0.4), // left minimum
     (top-origin.at(0) + 1.8, top-origin.at(1) + 0.3), // left minimum
     (top-origin.at(0) + 5, top-origin.at(1) + 1.5), // up to middle peak
     (top-origin.at(0) + 8.2, top-origin.at(1) + 0.3), // right minimum
     (top-origin.at(0) + 8.3, top-origin.at(1) + 0.4), // right minimum
-    (top-origin.at(0) + 9.5, top-origin.at(1) + 3.5), // up high again
+    (top-origin.at(0) + 9.5, top-origin.at(1) + 4), // up high again
     omega: 0,
     name: "potential-curve",
+    stroke: 1.5pt,
   )
 
   // Add "Free Energy" label
@@ -107,129 +108,130 @@
   )
 
   // Helper function to draw BaTiO3 unit cell
-  // TODO the face-centered oxygen atom positions need fixing and the lines overlap the atoms
+  let atom(pos, radius: 0.20, fill: luma(50), ..args) = {
+    circle(
+      pos, 
+      radius: radius,
+      stroke: none,
+      fill: fill,
+      ..args
+    )
+    circle(
+      (),
+      radius: radius,
+      stroke: none,
+      fill: gradient.radial(fill.lighten(75%), fill.lighten(25%), fill, fill.darken(15%), center: (30%, 30%)),
+    )
+  }
   let draw-unit-cell(center-x, center-y, ti-y, cell-name) = {
     let (x, y) = (center-x, center-y)
-    let z-offset = 0.3 // Consistent offset for back face
+    let z-offset = -1.0 // Consistent offset for back face
     let cube-style = (stroke: 0.7pt)
+
 
     // Draw unit cell cube with consistent offsets
     rect(
-      (x - 1, y - 1),
-      (x + 1, y + 1),
+      (x - 1, y - 1, 0),
+      (x + 1, y + 1, 0),
       ..cube-style,
       name: cell-name + "-front",
     ) // Front face
     line(
-      (x - 1, y - 1),
-      (x - 1 + z-offset, y - 1 + z-offset),
+      (x - 1, y - 1, 0),
+      (x - 1, y - 1, z-offset),
       ..cube-style,
       name: cell-name + "-left",
     ) // Left edge
     line(
-      (x + 1, y - 1),
-      (x + 1 + z-offset, y - 1 + z-offset),
+      (x + 1, y - 1, 0),
+      (x + 1, y - 1, z-offset),
       ..cube-style,
       name: cell-name + "-right",
     ) // Right edge
     line(
-      (x - 1 + z-offset, y - 1 + z-offset),
-      (x + 1 + z-offset, y - 1 + z-offset),
+      (x - 1, y - 1, z-offset),
+      (x + 1, y - 1, z-offset),
       ..cube-style,
       name: cell-name + "-back",
     ) // Back edge
     line(
-      (x - 1 + z-offset, y + 1 + z-offset),
-      (x + 1 + z-offset, y + 1 + z-offset),
+      (x - 1, y + 1, z-offset),
+      (x + 1, y + 1, z-offset),
       ..cube-style,
       name: cell-name + "-top-back",
     ) // Top back edge
     line(
-      (x - 1 + z-offset, y - 1 + z-offset),
-      (x - 1 + z-offset, y + 1 + z-offset),
+      (x - 1, y - 1, z-offset),
+      (x - 1, y + 1, z-offset),
       ..cube-style,
       name: cell-name + "-left-back",
     ) // Left back edge
     line(
-      (x + 1 + z-offset, y - 1 + z-offset),
-      (x + 1 + z-offset, y + 1 + z-offset),
+      (x + 1, y - 1, z-offset),
+      (x + 1, y + 1, z-offset),
       ..cube-style,
       name: cell-name + "-right-back",
     ) // Right back edge
+    line(
+      (x + 1, y - -1),
+      (x + 1, y - -1, z-offset),
+      ..cube-style,
+      name: cell-name + "top-right",
+    ) // top right edge
+    line(
+      (x + -1, y - -1),
+      (x + -1, y - -1, z-offset),
+      ..cube-style,
+      name: cell-name + "top-left",
+    ) // top right edge
 
-    // Draw Ba atoms (all 8 corners)
-    let ba-style = (stroke: none, fill: rgb("#00ffff"))
-    for (pos, suffix) in (
-      // Front face corners
-      ((x - 1, y - 1), "front-bl"),
-      ((x + 1, y - 1), "front-br"),
-      ((x - 1, y + 1), "front-tl"),
-      ((x + 1, y + 1), "front-tr"),
-      // Back face corners
-      ((x - 1 + z-offset, y - 1 + z-offset), "back-bl"),
-      ((x + 1 + z-offset, y - 1 + z-offset), "back-br"),
-      ((x - 1 + z-offset, y + 1 + z-offset), "back-tl"),
-      ((x + 1 + z-offset, y + 1 + z-offset), "back-tr"),
-    ) {
-      circle(
-        pos,
-        radius: 0.15,
-        ..ba-style,
-        name: cell-name + "-ba-" + suffix,
-      )
-    }
-
-    // Draw O atoms (all 6 face centers)
-    let o-style = (stroke: none, fill: red)
-    for (pos, suffix) in (
-      // Front and back face centers
-      ((x, y), "front"), // Front face center
-      ((x + z-offset, y + z-offset), "back"), // Back face center
-      // Face centers with consistent offsets
-      ((x, y + 1), "top"), // Top face center
-      ((x, y - 1), "bottom"), // Bottom face center
-      ((x - 1, y), "left"), // Left face center
-      ((x + 1, y), "right"), // Right face center
-    ) {
-      circle(
-        pos,
-        radius: 0.12,
-        ..o-style,
-        name: cell-name + "-o-" + suffix,
-      )
-    }
-
-    // Draw Ti atom (center, displaced)
-    let ti-style = (stroke: none, fill: gray)
-    circle(
-      (x + z-offset / 2, y + ti-y),
-      radius: 0.1,
-      ..ti-style,
-      name: cell-name + "-ti",
+    // Define helper functions for each atom style
+    let Ba-atom(pos, name) = atom(pos, fill: rgb("#00ffff"), name: cell-name + "-ba-" + name)
+    let O-atom(pos, name) = atom( pos, fill: red, name: cell-name + "-o-" + name)
+    let Ti-atom(pos) = atom( pos, fill: gray, name: cell-name + "-ti")
+    let Ti-O-bond(end-pos, name) = line(
+      ((x, y + ti-y, z-offset/2), 16%, end-pos),
+      end-pos,
+      stroke: 1pt,
+      name: cell-name + "-bond-" + name,
     )
-
-    // Draw Ti-O bonds
-    let bond-style = (stroke: (thickness: 0.5pt))
-    for (end-pos, suffix) in (
-      ((x, y), "front"), // Front face center
-      ((x + z-offset, y + z-offset), "back"), // Back face center
-      ((x, y + 1), "top"), // Top face center
-      ((x, y - 1), "bottom"), // Bottom face center
-      ((x - 1, y), "left"), // Left face center
-      ((x + 1, y), "right"), // Right face center
-    ) {
-      line(
-        (x + z-offset / 2, y + ti-y), // Ti position
-        end-pos,
-        ..bond-style,
-        name: cell-name + "-bond-" + suffix,
-      )
+    
+    // --- Back Plane (z = z-offset) ---
+    Ti-O-bond((x, y, z-offset), "back")
+    Ba-atom((x - 1, y - 1, z-offset), "back-bl")
+    Ba-atom((x + 1, y - 1, z-offset), "back-br")
+    Ba-atom((x - 1, y + 1, z-offset), "back-tl")
+    Ba-atom((x + 1, y + 1, z-offset), "back-tr")
+    O-atom((x, y, z-offset), "back")
+    
+    // --- Middle Plane (z = z-offset/2) ---
+    if ti-y >= 0 {
+      Ti-O-bond((x, y + 1, z-offset/2), "top")
     }
+    if ti-y <= 0 {
+      Ti-O-bond((x, y - 1, z-offset/2), "bottom")
+    }
+    Ti-O-bond((x - 1, y, z-offset/2), "left")
+    Ti-O-bond((x + 1, y, z-offset/2), "right")
+    O-atom((x, y + 1, z-offset/2), "top")
+    O-atom((x, y - 1, z-offset/2), "bottom")
+    O-atom((x - 1, y, z-offset/2), "left")
+    O-atom((x + 1, y, z-offset/2), "right")
+    Ti-atom((x, y + ti-y, z-offset/2))
+    
+    // --- Front Plane (z = 0) ---
+    Ti-O-bond((x, y, 0), "front")
+    Ba-atom((x - 1, y - 1, 0), "front-bl")
+    Ba-atom((x + 1, y - 1, 0), "front-br")
+    Ba-atom((x - 1, y + 1, 0), "front-tl")
+    Ba-atom((x + 1, y + 1, 0), "front-tr")
+    O-atom((x, y, 0), "front")
   }
 
   // Draw three unit cells with different Ti displacements
-  scale(0.75)
-  draw-unit-cell(-4, y-offset + 5, -0.2, "cell1")
-  draw-unit-cell(0, y-offset + 5, 0, "cell2")
-  draw-unit-cell(4, y-offset + 5, 0.2, "cell3")
+  scale(0.64)
+  set-origin("potential-curve.mid")
+  draw-unit-cell(-4.5, 2, -0.2, "cell1")
+  draw-unit-cell(-0.5, 2, 0, "cell2")
+  draw-unit-cell(3.5, 2, 0.2, "cell3")
 })

--- a/assets/high-entropy-alloy/high-entropy-alloy.typ
+++ b/assets/high-entropy-alloy/high-entropy-alloy.typ
@@ -1,0 +1,103 @@
+#import "@preview/cetz:0.3.4": canvas, draw
+#import draw: circle, content
+
+#set page(width: auto, height: auto, margin: 5pt)
+
+// Define the atom function with nice 3D shading
+#let atom(pos, color, radius: 0.3, element: none, name: none) = {
+  // Draw base circle with the main color
+  circle(pos, radius: radius, stroke: none, fill: color)
+
+  // Draw gradient overlay for 3D shading effect
+  circle(
+    pos,
+    radius: radius,
+    stroke: none,
+    fill: gradient.radial(
+      color.lighten(75%),
+      color,
+      color.darken(15%),
+      focal-center: (30%, 25%),
+      focal-radius: 5%,
+      center: (35%, 30%),
+    ),
+  )
+
+  // Add element label if provided
+  if element != none {
+    content(
+      pos,
+      text(fill: white, weight: "bold", size: 10pt)[#element],
+      anchor: "center",
+      name: name,
+    )
+  }
+}
+
+#canvas({
+  // Define colors for the high-entropy alloy (equivalent to the LaTeX colors but toned down)
+  let colors = (
+    rgb("#cc3333"),
+    rgb("#006666"),
+    rgb("#3333cc"),
+    rgb("#cc8000"),
+    rgb("#aaaaee"),
+  )
+
+  // Function to get a "random" color from the colors array
+  // Since Typst doesn't have a random function, we'll use a deterministic pattern
+  // based on position to create a random-looking distribution
+  let pseudo-random-color(i, j, k) = {
+    let index = calc.rem(i * 3 + j * 5 + k * 7, colors.len())
+    colors.at(index)
+  }
+
+  // viewing angle parameters
+  let x-factor = 0.3
+  let y-factor = -0.18
+  let z-spacing = 1.1
+
+  // Draw the alloy structure
+  // This is equivalent to the nested foreach loops in the LaTeX code
+  for i in range(12) {
+    for j in range(4) {
+      // First set of atoms (equivalent to the first nested loop in LaTeX)
+      for k in range(4) {
+        atom(
+          (-i + x-factor * j, y-factor * j + z-spacing * k),
+          pseudo-random-color(i, j, k),
+        )
+      }
+
+      // Second set of atoms (equivalent to the second nested loop in LaTeX)
+      for k in range(3) {
+        atom(
+          (-i + 0.5 + x-factor * j, y-factor * j + z-spacing * k + 0.65),
+          pseudo-random-color(i, j, k + 10),
+        )
+      }
+    }
+  }
+
+  // Draw the legend (moved further down)
+  let elements = (
+    ("Al", rgb("#cc3333")), // red!80 (toned down)
+    ("Co", rgb("#3333cc")), // blue!80 (toned down)
+    ("Cr", rgb("#006666")), // teal (toned down)
+    ("Fe", rgb("#cc8000")), // orange (toned down)
+    ("Ni", rgb("#aaaaee")), // blue!20 (toned down)
+  )
+
+  // Position the legend further down
+  let legend-y-start = 3
+  let legend-spacing = 0.8
+
+  for (idx, (element, color)) in elements.enumerate() {
+    // Draw atom with element symbol
+    atom(
+      (2.5, legend-y-start - idx * legend-spacing),
+      color,
+      element: element,
+    )
+  }
+})

--- a/assets/materials-informatics/materials-informatics.typ
+++ b/assets/materials-informatics/materials-informatics.typ
@@ -1,5 +1,5 @@
 #import "@preview/cetz:0.3.4": canvas, draw
-#import draw: line, content, rect
+#import draw: line, content, rect, circle
 
 #set page(width: auto, height: auto, margin: 5pt)
 
@@ -16,13 +16,37 @@
 }
 
 #let atom(pos, element, color: white, text-color: black, padding: 6pt, name: none) = {
-  draw.content(
+  // Calculate the radius based on padding to match the original size
+  let radius = padding + 7pt // Approximation of text size + padding
+
+  // Draw base circle with the main color
+  circle(
+    pos,
+    radius: radius,
+    stroke: none,
+    fill: color,
+  )
+
+  // Draw gradient overlay for 3D shading effect
+  circle(
+    pos,
+    radius: radius,
+    stroke: none,
+    fill: gradient.radial(
+      color.lighten(75%),
+      color,
+      color.darken(15%),
+      focal-center: (30%, 25%),
+      focal-radius: 5%,
+      center: (35%, 30%),
+    ),
+  )
+
+  // Draw the element text on top
+  content(
     pos,
     text(fill: text-color, weight: "bold", size: 14pt)[#element],
-    frame: "circle",
-    fill: color,
-    stroke: 0.5pt,
-    padding: padding,
+    anchor: "center",
     name: name,
   )
 }


### PR DESCRIPTION
Fix a bunch of issues with the typst implementation of the Ferroelectric Response diagram, bringing it closer to the TikZ version.
I mainly improved the shading of the atoms and fixed the wrong z-offset for some atoms and bonds. I also used the native z coordinates of CeTZ, rather than a manual offset.

Before:
![image](https://github.com/user-attachments/assets/6d1c6af8-73a4-489e-9fcf-5ffe0f185c52)

After:
![image](https://github.com/user-attachments/assets/0709f8cc-fb44-4c60-a589-dbf65a756f7c)
