### PR TITLE
Fix aspect ratio of diagrams on small screens

### DIFF
--- a/assets/matsubara-contour-2/matsubara-contour-2.yml
+++ b/assets/matsubara-contour-2/matsubara-contour-2.yml
@@ -9,4 +9,4 @@ tags:
   - contour integration
   - frequency sums
 description: >-
-  First deformation of the Matsubara contour in https://diagrams.janosh.dev/matsubara-contour-1 where C is expanded into a circle followed by taking the radius to infinity, plus two small clockwise circles C₁ and C₂ around the propagator poles. Since the integrand falls off faster than 1/p₀, the contribution from the large circle vanishes at infinity, leaving only the pole contributions. The small circles around the poles are there to remove again the contribution from the poles that was added by enclosing them in the counterclockwise contour C.
+  First deformation of the Matsubara contour in <https://diagrams.janosh.dev/matsubara-contour-1> where C is expanded into a circle followed by taking the radius to infinity, plus two small clockwise circles C₁ and C₂ around the propagator poles. Since the integrand falls off faster than 1/p₀, the contribution from the large circle vanishes at infinity, leaving only the pole contributions. The small circles around the poles are there to remove again the contribution from the poles that was added by enclosing them in the counterclockwise contour C.

--- a/assets/momentum-shell/momentum-shell.yml
+++ b/assets/momentum-shell/momentum-shell.yml
@@ -2,4 +2,4 @@ title: Momentum Shell
 tags:
   - physics
   - statistical mechanics
-description: See also https://diagrams.janosh.dev/ergodic.
+description: See also <https://diagrams.janosh.dev/ergodic>.

--- a/assets/pie-physics-chemistry-ml/pie-physics-chemistry-ml.yml
+++ b/assets/pie-physics-chemistry-ml/pie-physics-chemistry-ml.yml
@@ -5,5 +5,5 @@ tags:
   - machine learning
   - interdisciplinary
 description: |
-  A pie chart showing the 3 main research areas covered by the diagrams in https://github.com/janosh/diagrams: physics (Ψ), chemistry (ΔG), and machine learning (∑). The symbols represent wave functions, Gibbs free energy, and linear algebra, respectively.
+  A pie chart showing the 3 main research areas covered by the diagrams in <https://github.com/janosh/diagrams>: physics (Ψ), chemistry (ΔG), and machine learning (∑). The symbols represent wave functions, Gibbs free energy, and linear algebra, respectively.
 hide: true

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -8,6 +8,7 @@
   --light-code-bg: rgba(0, 123, 255, 0.1);
   --light-pre-bg: rgba(0, 0, 0, 0.03);
   --light-button-bg: #03eaa5;
+  --light-button-bg-hover: #02c78e;
   --light-button-text: #333;
   --light-border: rgba(0, 0, 0, 0.125);
   --light-highlight: #17a2b8;
@@ -31,6 +32,7 @@
   --dark-code-bg: rgba(255, 255, 255, 0.1);
   --dark-pre-bg: rgba(255, 255, 255, 0.05);
   --dark-button-bg: teal;
+  --dark-button-bg-hover: rgb(89, 89, 117);
   --dark-button-text: #eee;
   --dark-border: rgba(255, 255, 255, 0.125);
   --dark-highlight: mediumaquamarine;
@@ -54,6 +56,10 @@
   --code-bg: light-dark(var(--light-code-bg), var(--dark-code-bg));
   --pre-bg: light-dark(var(--light-pre-bg), var(--dark-pre-bg));
   --button-bg: light-dark(var(--light-button-bg), var(--dark-button-bg));
+  --button-bg-hover: light-dark(
+    var(--light-button-bg-hover),
+    var(--dark-button-bg-hover)
+  );
   --button-text: light-dark(var(--light-button-text), var(--dark-button-text));
   --border: light-dark(var(--light-border), var(--dark-border));
   --highlight: light-dark(var(--light-highlight), var(--dark-highlight));
@@ -78,20 +84,16 @@ body {
   color: var(--text-color);
   line-height: 1.6;
 }
-
 :where(h1, h2, h3, h4, p, footer) {
   text-align: center;
 }
-
 a {
   color: var(--link-color);
   text-decoration: none;
 }
-
 a:hover {
   color: var(--link-hover);
 }
-
 /* :where() needed to make less specific to not override svelte-multiselect button CSS */
 :where(button) {
   color: var(--button-text);
@@ -103,13 +105,10 @@ a:hover {
   transition: transform 0.2s, background-color 0.2s;
   cursor: pointer;
 }
-
-button:hover {
-  background: var(--button-bg);
-  transform: scale(1.02);
+:where(button:hover) {
+  background: var(--button-bg-hover);
 }
-
-button.link {
+:where(button.link) {
   background: none;
   border: none;
   color: var(--link-color);
@@ -117,12 +116,10 @@ button.link {
   cursor: pointer;
   padding: 0;
 }
-
 ::highlight(highlight-match) {
   color: var(--highlight);
   text-decoration: underline;
 }
-
 div.multiselect {
   --sms-options-bg: var(--page-bg);
   --sms-bg: var(--input-bg);

--- a/site/src/lib/CodeBlock.svelte
+++ b/site/src/lib/CodeBlock.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Iconify from '@iconify/svelte'
   import hljs from 'highlight.js/lib/core'
   import latex from 'highlight.js/lib/languages/latex'
   import 'highlight.js/styles/vs2015.css'
@@ -17,11 +18,16 @@
     tex_file_uri?: string
   }
   let { code, repo_link, title, tex_file_uri = `` }: Props = $props()
+  let ext = $derived(title?.split(`.`).pop() as 'typ' | 'ext')
+  const lang_icon = $derived(
+    { typ: `simple-icons:typst`, tex: `file-icons:latex` }[ext],
+  )
 </script>
 
 <div>
   {#if title}
     <h3>
+      <Iconify icon={lang_icon} inline />&nbsp;
       {title} <small>({code.split(`\n`).length} lines)</small>
     </h3>
   {/if}
@@ -58,8 +64,9 @@
     bottom: calc(100% - 1em);
     left: 1em;
     background: var(--button-bg);
-    padding: 2pt 8pt;
+    padding: 0 8pt;
     border-radius: 3pt 3pt 0 0;
+    font-size: medium;
   }
   h3 small {
     font-weight: 200;

--- a/site/src/lib/DiagramCard.svelte
+++ b/site/src/lib/DiagramCard.svelte
@@ -12,11 +12,7 @@
   let { slug, title, description, tags } = $derived(item)
 </script>
 
-<a
-  href={slug}
-  transition:fade={{ duration: 200 }}
-  {...rest}
->
+<a href={slug} transition:fade={{ duration: 200 }} {...rest}>
   <h2 id={slug}>{title}</h2>
   {#if format === `full`}
     <Tags {tags} style="color: var(--text-color); margin-block: 0 1em" />

--- a/site/src/lib/Tags.svelte
+++ b/site/src/lib/Tags.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements'
   import { filters } from './state.svelte'
 
   interface Props {
     tags: string[]
+    btn_props?: HTMLAttributes<HTMLButtonElement>
     [key: string]: unknown
   }
-  let { tags = [], ...rest }: Props = $props()
+  let { tags = [], btn_props = {}, ...rest }: Props = $props()
 </script>
 
 <p class="tags" {...rest}>
@@ -20,6 +22,7 @@
           filters.tags = [...filters.tags, { label: tag, count: 0 }]
         }
       }}
+      {...btn_props}
     >
       {tag}
     </button>
@@ -32,7 +35,6 @@
     flex-wrap: wrap;
     place-content: center;
     gap: 4pt;
-    padding: 0;
     margin: 1em;
   }
   p.tags button {
@@ -41,11 +43,5 @@
     color: var(--text-secondary);
     padding: 2pt 4pt;
     border-radius: 3pt;
-    line-height: 1;
-    transition: background-color 0.2s ease;
-  }
-  p.tags button:hover {
-    background-color: var(--card-bg);
-    color: var(--text-color);
   }
 </style>

--- a/site/src/routes/[slug]/+page.svelte
+++ b/site/src/routes/[slug]/+page.svelte
@@ -63,7 +63,7 @@
 {/if}
 
 <section class="description">
-  <Tags {tags} />
+  <Tags {tags} btn_props={{ style: `cursor: default` }} />
 
   {#if description}
     {@html description}
@@ -95,9 +95,6 @@
   <Icon icon="octicon:code" inline />&nbsp; Code
 </h2>
 {#if code.tex}
-  <h3 class="code-title">
-    <Icon icon="file-icons:latex" inline style="color: var(--text-color)" />&nbsp; LaTeX
-  </h3>
   <CodeBlock
     code={code.tex}
     title="{slug}.tex"
@@ -105,11 +102,7 @@
     tex_file_uri="{base_uri}.tex"
   />
 {/if}
-
 {#if code.typst}
-  <h3 class="code-title">
-    <Icon icon="simple-icons:typst" inline />&nbsp; Typst
-  </h3>
   <CodeBlock
     code={code.typst}
     title="{slug}.typ"
@@ -120,7 +113,7 @@
 <PrevNext
   items={data.diagrams.map((diagram) => [diagram.slug, diagram])}
   current={data.slug}
-  style="max-width: 55em; margin: auto"
+  style="max-width: 50em; margin: auto"
 >
   {#snippet children({ item, kind })}
     {@const [slug, diagram] = item as [string, Diagram]}
@@ -146,7 +139,7 @@
   :where(h1, h2) {
     border-bottom: 2px solid var(--link-hover);
     max-width: 12em;
-    margin: 2em auto 1em;
+    margin: 1em auto;
     padding-bottom: 8pt;
   }
   section {
@@ -189,8 +182,5 @@
     position: absolute;
     top: 2em;
     left: 2em;
-  }
-  .code-title {
-    margin-bottom: -1em;
   }
 </style>

--- a/site/src/routes/[slug]/+page.svelte
+++ b/site/src/routes/[slug]/+page.svelte
@@ -165,6 +165,7 @@
     max-width: min(850px, 90vw);
     height: auto;
     max-height: 90vh;
+    object-fit: scale-down;
     margin: 2em auto;
     border-radius: 1ex;
     display: block;


### PR DESCRIPTION
On a 800×500 screen, the size of `<img>` would be 90vw × 90vh, or 720×450 in pixels, stretching the image unnaturally.

Changing [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) from `fill` (default) to `scale-down` would resolve the problem.

## Example ([matsubara-contour-2](https://diagrams.janosh.dev/matsubara-contour-2))

### Before

<img width="800" alt="图片" src="https://github.com/user-attachments/assets/02f47e1d-9020-48ca-8a1e-6aa4c3e0f21e" />

### After

<img width="800" alt="图片" src="https://github.com/user-attachments/assets/50497e93-cbf0-4bf8-a095-31b2731918a3" />

